### PR TITLE
Updated dependency to get build working again

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 authors = ["Mads Røskar <madshvero@gmail.com>", "Frank Lyder Bredland"]
 
 [dependencies]
-cocoa = "0.10.0"
+cocoa = "0.20.1"
 libc = "0.2.0"
 
 [build-dependencies]


### PR DESCRIPTION
`cargo run --example hotkey` now works again